### PR TITLE
日常维护 | 与 Databend 的一些变化进行同步

### DIFF
--- a/docs/content/docs/contribute-to-databend/write-and-run-tests.md
+++ b/docs/content/docs/contribute-to-databend/write-and-run-tests.md
@@ -169,7 +169,7 @@ goldenfiles 的报错可能会涉及多个测试文件，受限于长文本支�
 
 ## 功能测试
 
-功能测试暂时出现两种方案并行的情况，除了旧有的 stateless/stateful 测试方案外，还引入了全新的 SQL 逻辑测试，后续 stateless 测试会过渡到 SQL 逻辑测试上。
+功能测试主要由 SQL 逻辑测试（sqllogictest）和 stateful 测试两个部分组成。
 
 从本质上讲，这两类功能测试流程相同：
 
@@ -177,7 +177,7 @@ goldenfiles 的报错可能会涉及多个测试文件，受限于长文本支�
 - 使用对应的客户端/驱动执行查询。
 - 对比查询情况和预期行为之间的差异，判断测试是否通过。
 
-但是，在设计上，SQL 逻辑测试可以提供更全面的能力：
+在设计上，SQL 逻辑测试可以提供更全面的能力：
 
 - 拓展比较结果文件的方式到其他协议（涵盖 http handler）。
 - 提示每个语句的结果。
@@ -186,9 +186,36 @@ goldenfiles 的报错可能会涉及多个测试文件，受限于长文本支�
 
 ### 编写
 
-**stateless/stateful 测试**
+**SQL 逻辑测试**
 
-stateless/stateful 测试放在 `tests/suites` 目录下：
+SQL 逻辑测试放在 `tests/logictest` 目录下。
+
+语句规范在 sqlite sqllogictest 的基础上进行拓展，可以分成以下几类：
+
+- `statement ok` ：SQL 语句正确，且成功执行。
+- `statement error <error regex>` ：SQL 语句输出期望的错误。
+- `statement query <desired_query_schema_type> <options> <labels>` ：SQL语句成功执行并输出预期结果。
+
+```sql
+statement query B label(mysql,http)
+select count(1) > 1 from information_schema.columns;
+
+----  mysql
+1
+
+----  http
+true
+```
+
+上面的例子展示了如何对 mysql 和 http 分别设计对应的输出结果。其中 `B` 表示结果为布尔类型，`label` 用来标记协议。
+
+SQL 逻辑测试同样支持测试集生成 `python3 gen_suites.py` 。
+
+**stateful 测试**
+
+stateful 测试放在 `tests/suites` 目录下：
+
+> 这里展示的是一类 stateless 写法，stateful 与之类似，区别在于 stateful 会加载数据集并执行查询。
 
 - 输入是一系列 sql 语句，对应目录中的 `*.sql` 文件。
 
@@ -221,65 +248,16 @@ stateless/stateful 测试放在 `tests/suites` 目录下：
     SELECT INET_ATON('hello');-- {ErrorCode 1060}
     ```
 
-**SQL 逻辑测试**
-
-SQL 逻辑测试放在 `tests/logictest` 目录下。
-
-语句规范在 sqlite sqllogictest 的基础上进行拓展，可以分成以下几类：
-
-- `statement ok` ：SQL 语句正确，且成功执行。
-- `statement error <error regex>` ：SQL 语句输出期望的错误。
-- `statement query <desired_query_schema_type> <options> <labels>` ：SQL语句成功执行并输出预期结果。
-
-```sql
-statement query B label(mysql,http)
-select count(1) > 1 from information_schema.columns;
-
-----  mysql
-1
-
-----  http
-true
-```
-
-上面的例子展示了如何对 mysql 和 http 分别设计对应的输出结果。其中 `B` 表示结果为布尔类型，`label` 用来标记协议。
-
-SQL 逻辑测试同样支持测试集生成 `python3 gen_suites.py` 。
-
 ### 运行
 
-> 由于 stateless/stateful 测试和 sqllogictest 测试均由 Python 编写，在运行前请确保你已经安装全部的依赖。
+> 由于 stateful 测试和 sqllogictest 测试均由 Python 编写，在运行前请确保你已经安装全部的依赖。
 
 这几类测试都有对应的 `make` 命令，并支持集群模式测试：
 
-- `stateless` 测试：`make stateless-test` & `make stateless-cluster-test` 。
-- `stateful` 测试：`make stateful-test` & `make stateful-cluster-test` 。（一般在 CI 中运行，本地需要正确配置 MINIO 环境）。
 - `sqllogictest` 测试：`make sqllogic-test` & `make sqllogic-cluster-test` 。
+- `stateful` 测试：`make stateful-test` & `make stateful-cluster-test` 。（一般在 CI 中运行，本地需要正确配置 MINIO 环境）。
 
 ### 排查
-
-**stateless/stateful 测试**
-
-目前 stateless/stateful 测试能够提供文件级的报错和 diff ，但无法确定报错是由哪一条语句产生。
-
-```
-02_0057_function_nullif:                                                [ FAIL ] - result differs with:
---- /projects/datafuselabs/databend/tests/suites/0_stateless/02_function/02_0057_function_nullif.result
-+++ /projects/datafuselabs/databend/tests/suites/0_stateless/02_function/02_0057_function_nullif.stdout
-@@ -3,7 +3,7 @@
- 1
- 1
- NULL
--a
-+b
- b
- a
- NULL
-
-Having 1 errors! 207 tests passed.                     0 tests skipped.
-The failure tests:
-    /projects/datafuselabs/databend/tests/suites/0_stateless/02_function/02_0057_function_nullif.sql
-```
 
 **sqllogictest 测试**
 
@@ -306,7 +284,32 @@ Parsed Statement
 make: *** [Makefile:82: sqllogic-test] Error 1
 ```
 
+**stateful 测试**
+
+目前 stateful 测试能够提供文件级的报错和 diff ，但无法确定报错是由哪一条语句产生。
+
+> 这里展示的是过去 stateless 引发的报错，stateful 与之类似。
+
+```
+02_0057_function_nullif:                                                [ FAIL ] - result differs with:
+--- /projects/datafuselabs/databend/tests/suites/0_stateless/02_function/02_0057_function_nullif.result
++++ /projects/datafuselabs/databend/tests/suites/0_stateless/02_function/02_0057_function_nullif.stdout
+@@ -3,7 +3,7 @@
+ 1
+ 1
+ NULL
+-a
++b
+ b
+ a
+ NULL
+
+Having 1 errors! 207 tests passed.                     0 tests skipped.
+The failure tests:
+    /projects/datafuselabs/databend/tests/suites/0_stateless/02_function/02_0057_function_nullif.sql
+```
+
 **提示**
 
-- stateless/stateful 超时类错误（Timeout!）的默认时间限制为 10 分钟。为方便排查，可以将 `databend-test` 文件中的 `timeout` 改短。
 - 移除 `databend-query-standalone-embedded-meta.sh` 等脚本中的 `nohup` 有助于在测试时同时输出日志到终端，可能同样有助于排查。
+- stateful 超时类错误（Timeout!）的默认时间限制为 10 分钟。为方便排查，可以将 `databend-test` 文件中的 `timeout` 改短。

--- a/docs/content/docs/contributing/outline.md
+++ b/docs/content/docs/contributing/outline.md
@@ -46,6 +46,7 @@ giscus = true
 **已上线**
 
 - Databend 源码阅读： 开篇
+- Databend 源码阅读： Query Server 启动、Session 管理及请求处理
 
 **规划中**
 

--- a/docs/content/docs/productivity-topics/quality-assurance-in-databend.md
+++ b/docs/content/docs/productivity-topics/quality-assurance-in-databend.md
@@ -113,14 +113,15 @@ Databend 目前共有接近 800 条单元测试，对重点函数做到了应测
 
 每个功能都是由若干函数/过程组成的，功能测试正是为评估功能的正确性而设立。功能测试会以 standalone 和 cluster 两种模式进行，以确保 Databend 的分布式执行功能，。
 
-Databend 的功能测试主要由 `stateless` 测试和 `stateful` 测试两个部分组成。其中 `stateless` 测试不需要加载数据集，而 `stateful` 测试会要求装载数据集。这两类测试都可以在 `tests/suit` 目录下找到。
+当前 Databend 的功能测试主要由 `sqllogictest` 测试和 `stateful` 测试两个部分组成，这两类测试都可以在 `tests/suit` 目录下找到。
 
-Databend 功能测试目前采用 Clickhouse 的方法，将测试所需执行的 SQL 集放入一个文件，预期结果集放入另一个文件。在测试时会调用 SQL 集生成对应的测试结果集，并与预期结果集进行对比。
+`sqllogictest` 即 SQL 逻辑测试，是为了解决之前的 stateless 的一些旧有问题而专门设计实现的测试方案。[RFC | New SQL Logic Test Framework](https://databend.rs/doc/contributing/rfcs/new_sql_logic_test_framework) 中介绍了其基本背景和方案概要。
+
+Databend `stateful` 功能测试目前采用 Clickhouse 的方法，将测试所需执行的 SQL 集放入一个文件，预期结果集放入另一个文件。在测试时会调用 SQL 集生成对应的测试结果集，并与预期结果集进行对比。
 
 ## 进一步探索
 
 上面简要介绍了 Databend 日常开发中涉及的质量保障内容，但质量保障体系仍然处于持续演进的过程中，这里列出了一些值得关注的内容：
 
-- SQL 逻辑测试框架（sqllogictest），目前的 stateless/stateful 测试没有扩展到其他协议，并且无法区分具体的执行语句，也不支持错误处理、语句扩展等能力。目前[已建立 RFC 并计划在 `tests/logictest` 完成实施](https://github.com/datafuselabs/databend/pull/5048)。
-- SQLancer，一款针对数据库管理系统DBMS的自动化安全测试工具。Databend 计划使用这一工具探测潜在的逻辑错误，目前[作为 OSPP 2022 项目接受学生报名](https://summer-ospp.ac.cn/#/org/prodetail/226460211)。
+- SQLancer，一款针对数据库管理系统DBMS的自动化安全测试工具。Databend 计划使用这一工具探测潜在的逻辑错误，目前[作为 OSPP 2022 项目](https://summer-ospp.ac.cn/#/org/prodetail/226460211) ，由 [@hanyisong](https://github.com/hanyisong) 同学负责开发，可以关注 [SQLancer supports databend](https://github.com/datafuse-extras/sqlancer/pull/1) 。
 - [Domain-aware Fuzzing](https://github.com/datafuselabs/databend/issues/1549)，Databend 有一个针对 SQL Parser 的简单模糊测试，但只是生成一些随机字符串。一个比较值得探索的方式是像 sqlsmith 那样的方案，生成更有意义和具有针对性的测试用例。

--- a/docs/content/docs/productivity-topics/quality-assurance-in-databend.md
+++ b/docs/content/docs/productivity-topics/quality-assurance-in-databend.md
@@ -113,7 +113,7 @@ Databend 目前共有接近 800 条单元测试，对重点函数做到了应测
 
 每个功能都是由若干函数/过程组成的，功能测试正是为评估功能的正确性而设立。功能测试会以 standalone 和 cluster 两种模式进行，以确保 Databend 的分布式执行功能，。
 
-当前 Databend 的功能测试主要由 `sqllogictest` 测试和 `stateful` 测试两个部分组成，这两类测试都可以在 `tests/suit` 目录下找到。
+当前 Databend 的功能测试主要由 `sqllogictest` 测试和 `stateful` 测试两个部分组成，这两类测试都可以在 `tests` 目录下找到。
 
 `sqllogictest` 即 SQL 逻辑测试，是为了解决之前的 stateless 的一些旧有问题而专门设计实现的测试方案。[RFC | New SQL Logic Test Framework](https://databend.rs/doc/contributing/rfcs/new_sql_logic_test_framework) 中介绍了其基本背景和方案概要。
 


### PR DESCRIPTION
1. 更新 `源码阅读：开篇` 中的模块路径，Databend 近期调整了模块组织形式并增补了对各个模块的简单说明。
2. 更新 `质量保障` 一文中对功能测试和进一步探索的描述，sqllogictest 和 sqlancer
3. 更新 `如何为 Databend 添加新的测试` 中对功能测试的一些表述，尽管 stateless 测试还没有完全移除，但我们将不再继续关注这一部分。